### PR TITLE
Update tslint to v5.4.2

### DIFF
--- a/config/basic.json
+++ b/config/basic.json
@@ -4,6 +4,7 @@
         "arrow-parens": true,
         "arrow-return-shorthand": false,
         "ban-types": [true],
+        "binary-expression-operand-order": false, // We don't think it is important.
         "callable-types": true,
         "class-name": true,
         "completed-docs": false,
@@ -82,6 +83,7 @@
         "space-before-function-paren": [true, {
             "named": "never"
         }],
+        "switch-final-break": [true, "always"],
         "triple-equals": true,
         "typeof-compare": true,
         "unified-signatures": false,

--- a/config/typecheck.json
+++ b/config/typecheck.json
@@ -19,6 +19,7 @@
         // "restrict-plus-operands": false,
         // "return-undefined": false,
         // "strict-boolean-expressions": false,
-        // "strict-type-predicates": false
+        // "strict-type-predicates": false,
+        // "use-default-type-parameter": true
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   },
   "homepage": "https://github.com/voyagegroup/tslint-config-fluct",
   "peerDependencies": {
-    "tslint": "^5.3.2"
+    "tslint": "^5.4.2"
   },
   "devDependencies": {
-    "tslint": "^5.3.2",
+    "tslint": "^5.4.2",
     "typescript": "^2.3.2"
   }
 }


### PR DESCRIPTION
tslintのversionがあがっていたので新しいrule追加したい。

- https://palantir.github.io/tslint/rules/binary-expression-operand-order/
  - これはいらないんじゃないかなとおもった。
- https://palantir.github.io/tslint/rules/switch-final-break/
  - nishikiでは1箇所直す必要があるけど、あっていいかなとおもった。

Fix #19 