### PR TITLE
Update tslint to 5.8 

### DIFF
--- a/config/basic.json
+++ b/config/basic.json
@@ -54,6 +54,7 @@
 
         "no-parameter-reassignment": true,
         "no-require-imports": true,
+        "no-return-await": true, // Sort with https://github.com/voyagegroup/eslint-config-fluct
         "no-reference-import": true,
         "no-shadowed-variable": false,
         "no-sparse-arrays": true,

--- a/config/basic.json
+++ b/config/basic.json
@@ -55,6 +55,7 @@
         "no-parameter-properties": true,
 
         "no-parameter-reassignment": true,
+        "no-redundant-jsdoc": false,
         "no-require-imports": true,
         "no-return-await": true, // Sort with https://github.com/voyagegroup/eslint-config-fluct
         "no-reference-import": true,

--- a/config/basic.json
+++ b/config/basic.json
@@ -67,6 +67,11 @@
         "no-switch-case-fall-through": true,
         "no-this-assignment": true,
         "no-trailing-whitespace": true,
+        // FYI: https://palantir.github.io/tslint/rules/no-unnecessary-class/
+        // I think it's a bit strange if there is a class which only have static members.
+        // and I also think there is a chance to refactor it.
+        // But other type is not a problem. It may be a work in progress.
+        "no-unnecessary-class": ["allow-constructor-only", "allow-empty-class"],
         "no-unnecessary-initializer": true,
         "no-unnecessary-callback-wrapper": true,
         "no-unsafe-finally": true,

--- a/config/basic.json
+++ b/config/basic.json
@@ -29,6 +29,7 @@
         "no-default-export": true,
         "no-duplicate-imports": true,
         "no-duplicate-super": true,
+        "no-duplicate-switch-case": true, // This would be the possible error.         
         "no-duplicate-variable": true,
         "no-empty-interface": false,
         "no-eval": true,

--- a/config/basic.json
+++ b/config/basic.json
@@ -3,6 +3,7 @@
         "array-type": false,
         "arrow-parens": true,
         "arrow-return-shorthand": false,
+        "ban-comma-operator": true, // This is confusable.
         "ban-types": [true],
         "binary-expression-operand-order": false, // We don't think it is important.
         "callable-types": true,

--- a/config/basic.json
+++ b/config/basic.json
@@ -91,7 +91,6 @@
         "space-within-parens": false,
         "switch-final-break": [true, "always"],
         "triple-equals": true,
-        "typeof-compare": true,
         "unified-signatures": false,
         "use-isnan": true,
         "variable-name": [true,

--- a/config/basic.json
+++ b/config/basic.json
@@ -34,6 +34,10 @@
         "no-duplicate-variable": true,
         "no-empty-interface": false,
         "no-eval": true,
+        // In almost case, TypeScript code is used only for production code,
+        // We use plain JavaScript for tools in our repository. So I don't check `devDependencies`.
+        // See https://palantir.github.io/tslint/rules/no-implicit-dependencies/ 
+        "no-implicit-dependencies": true,
         "no-import-side-effect": false,
         "no-internal-module": true,
         "no-invalid-template-strings": true,

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   },
   "homepage": "https://github.com/voyagegroup/tslint-config-fluct",
   "peerDependencies": {
-    "tslint": "^5.7.0"
+    "tslint": "^5.8.0"
   },
   "devDependencies": {
-    "tslint": "^5.7.0",
+    "tslint": "^5.8.0",
     "typescript": "^2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "TSLint configurations that are used by fluct division of VOYAGE GROUP, Inc.",
   "license": "MIT",
   "scripts": {
-    "test": "tslint --project ./tsconfig.json --type-check --config ./tslint.json"
+    "test": "tslint --project ./tsconfig.json --config ./tslint.json"
   },
   "engines": {
     "node": ">6.9.1",

--- a/tslint.json
+++ b/tslint.json
@@ -3,5 +3,8 @@
         "./config/basic.json",
         "./config/typecheck.json"
     ],
-    "defaultSeverity": "error"
+    "defaultSeverity": "error",
+    "linterOptions": {
+        "exclude": []
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,12 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
+
 babel-code-frame@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -29,6 +35,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+builtin-modules@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -39,9 +49,23 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-colors@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+chalk@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.2.0.tgz#477b3bf2f9b8fd5ca9e429747e37f724ee7af240"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
+color-convert@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
+  dependencies:
+    color-name "^1.1.1"
+
+color-name@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 commander@^2.9.0:
   version "2.11.0"
@@ -55,7 +79,7 @@ diff@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
 
-escape-string-regexp@^1.0.2:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -83,6 +107,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -139,16 +167,23 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
 tslib@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.1.tgz#bc8004164691923a79fe8378bbeb3da2017538ec"
 
-tslint@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.7.0.tgz#c25e0d0c92fa1201c2bc30e844e08e682b4f3552"
+tslint@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.8.0.tgz#1f49ad5b2e77c76c3af4ddcae552ae4e3612eb13"
   dependencies:
     babel-code-frame "^6.22.0"
-    colors "^1.1.2"
+    builtin-modules "^1.1.1"
+    chalk "^2.1.0"
     commander "^2.9.0"
     diff "^3.2.0"
     glob "^7.1.1"
@@ -156,11 +191,11 @@ tslint@^5.7.0:
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.7.1"
-    tsutils "^2.8.1"
+    tsutils "^2.12.1"
 
-tsutils@^2.8.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.8.1.tgz#3771404e7ca9f0bedf5d919a47a4b1890a68efff"
+tsutils@^2.12.1:
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.12.1.tgz#f4d95ce3391c8971e46e54c4cf0edb0a21dd5b24"
   dependencies:
     tslib "^1.7.1"
 


### PR DESCRIPTION
## Release note

https://github.com/palantir/tslint/releases/tag/5.8.0

## Untouched features

> [new-rule-option] "ignore-blank-lines" option for no-trailing-whitespace rule (#3346)

I don't think these are useful.

> [new-rule-option] "exclude-class-expressions" option for max-classes-per-file rule 
> [new-rule-option] no-unnecessary-type-assertion supports a whitelist of types to ignore
 
We disable these rules.

> [new-rule-option] trailing-comma adds option "esSpecCompliant" to make it compatible with the ES spec regarding trailing commas after object/array rest and rest parameters. 
> [new-rule-option] jsdoc-format adds option "check-multiline-start" to enforce the first line of a multiline JSDoc comment to be empty.
> [new-rule-option] "check-parameter-property" option for member-access rule
> [new-rule-option] "grouped-imports" option for ordered-imports rule
> [new-rule-option] "never" option for object-literal-shorthand disallows shorthand notation
> [new-rule-option] "module-source-path" for ordered-imports allows sorting imports by trailing end of path

We don't have these rule.


## Related issues

- Fix https://github.com/voyagegroup/tslint-config-fluct/issues/37
