### PR TITLE
Enable 'strict-bound-class-methods' option for 'semicolon'

### DIFF
--- a/config/basic.json
+++ b/config/basic.json
@@ -97,7 +97,7 @@
         "prefer-template": false, // Sort with voyagegroup/eslint-config-fluct
         "quotemark": [true, "single", "jsx-single", "avoid-escape"], // Sort with voyagegroup/eslint-config-fluct
         "radix": true,
-        "semicolon": [true, "always"],
+        "semicolon": [true, "always", "strict-bound-class-methods"],
         "space-before-function-paren": [true, {
             "named": "never"
         }],


### PR DESCRIPTION
- This follows up https://github.com/voyagegroup/tslint-config-fluct/pull/38, #37
- This option is for https://palantir.github.io/tslint/rules/semicolon/