### PR TITLE
Revice 'member-ordering' rule.

### DIFF
--- a/config/basic.json
+++ b/config/basic.json
@@ -19,7 +19,16 @@
         "linebreak-style": [true, "LF"],
         "max-classes-per-file": false,
         "max-file-line-count": false, // This is meaningless today.
-        "member-ordering": [true, "variables-before-functions"],
+        // - I don't think it's not efffective to sort the order by public/private/protected.
+        "member-ordering": [true, {
+            "order": [
+              "static-field",
+              "static-method",
+              "instance-field",
+              "constructor",
+              "instance-method"
+            ]
+        }],
         "new-parens": true,
         "newline-before-return": false,
         "newline-per-chained-call": false,


### PR DESCRIPTION
This would be a breaking change about the order of 'static' members.

Motivation
------------

- [`member-ordering`](https://palantir.github.io/tslint/rules/member-ordering/) has the new options about sorting.
    - The previous option remains for a compatibility.
- So I'd like to clean up it.

Detailed Design
---------------

This changes aims to sort members like this:

```typescript
class Example {

    static a: number = 0;
    static b(): void;

    c: number;

    constructor();

    d(): void;
}
```

This does not sort by a visibility modifier like `public` or `private`. I don't want to change the place of their code chunk if I need to change the visibility for some members.

Alternative Proposals
-------------------------

It disables `member-ordering`. This would not cause any breaking change. And you can free to sort your type's definitions.

`tsc` tracks where this member is defined, so there is no coding regression which might causes a serious possible error.

However, this also wastes a reviewer's thinking resource on reviewing a code from the other.