### PR TITLE
Update tslint5.10

### DIFF
--- a/config/basic.json
+++ b/config/basic.json
@@ -8,6 +8,7 @@
         "binary-expression-operand-order": false, // We don't think it is important.
         "callable-types": true,
         "class-name": true,
+        "comment-format": false, // We don't have to sort it in this lint.
         "completed-docs": false,
         "curly": true,
         "cyclomatic-complexity": false, // This is meaningless for daily working.
@@ -43,6 +44,9 @@
         "no-duplicate-switch-case": true, // This would be the possible error.         
         "no-duplicate-variable": true,
         "no-dynamic-delete": true, // https://github.com/voyagegroup/tslint-config-fluct/issues/41#issuecomment-357874370
+        // Sort with eslint-config-fluct.
+        // ref: `no-empty` and `no-empty-function`
+        "no-empty": [true, "allow-empty-functions"],
         "no-empty-interface": false,
         "no-eval": true,
         // In almost case, TypeScript code is used only for production code,
@@ -106,6 +110,7 @@
         "prefer-object-spread": false, // We don't have any opinion to it...
         "prefer-switch": false,
         "prefer-template": false, // Sort with voyagegroup/eslint-config-fluct
+        "prefer-while": true,
         "quotemark": [true, "single", "jsx-single", "avoid-escape"], // Sort with voyagegroup/eslint-config-fluct
         "radix": true,
         "semicolon": [true, "always", "strict-bound-class-methods"],

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
   },
   "homepage": "https://github.com/voyagegroup/tslint-config-fluct",
   "peerDependencies": {
-    "tslint": "^5.9.1"
+    "tslint": "^5.10.0"
   },
   "devDependencies": {
-    "tslint": "^5.9.1",
+    "tslint": "^5.10.0",
     "typescript": "^2.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,9 +202,9 @@ tslib@^1.8.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.8.1.tgz#6946af2d1d651a7b1863b531d6e5afa41aa44eac"
 
-tslint@^5.9.1:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.9.1.tgz#1255f87a3ff57eb0b0e1f0e610a8b4748046c9ae"
+tslint@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
   dependencies:
     babel-code-frame "^6.22.0"
     builtin-modules "^1.1.1"


### PR DESCRIPTION
Release Note
-----------

https://github.com/palantir/tslint/releases/tag/5.10.0

Detailed Design
--------------

- New options for promise-function-async
    - We're disabling its rule. So this commit does not enable a new option.
- Enable `no-empty` rule
   - I think we should sort this rule with eslint-config-fluct.
   - ESLint has `no-empty` and `no-empty-function`.
      - https://github.com/voyagegroup/eslint-config-fluct/blob/c7924e0cb27a110dcf2584b6f3a10a60e3b76407/config/eslintrc_core.js#L26
      - https://github.com/voyagegroup/eslint-config-fluct/blob/c7924e0cb27a110dcf2584b6f3a10a60e3b76407/config/eslintrc_core.js#L75